### PR TITLE
Suction controller and pressure sensor intg

### DIFF
--- a/klippy/extras/XGZP6847D_sensor.py
+++ b/klippy/extras/XGZP6847D_sensor.py
@@ -1,0 +1,145 @@
+#################################################################
+# Klippy Suction monitoring Module @ Albatross
+# Description: This module provides klippy interface for suction
+#              i2c-based sensor (XGZP6847D) with asynchronous 
+#              read for pressure and temperature
+# Date: 2025-06-26
+# Version: 0.1
+# Owner: Mo
+#################################################################
+from . import bus
+import logging
+
+# "I2C device factory setting slave address: 0X6D."
+XGZP6847D_FACTORY_ADDRESS = 0x6D
+
+REG_ADD_P_DATA_MSB = 0x06
+REG_ADD_P_DATA_CSB = 0x07
+REG_ADD_P_DATA_LSB = 0x08
+REG_ADD_T_DATA_MSB = 0x09
+REG_ADD_T_DATA_LSB = 0x0A
+REG_ADD_CMD = 0x30
+REG_DATA_CMD = 0x0A # start combined conversion pressure and temperature
+# Sampling takes 20ms at most
+SAMPLING_CYCLE_MS = 5.
+MAX_SAMPLING_CYCLE = 6
+
+READ_READY_STATE = 0
+
+# K vlue for the datasheet
+# Pressure Range(Absolute Value-KPa）K valueSensor Pressure Range Example
+# 1000≤Pressure Range 4 0~1000kPa; 0~1500kPa; -100~1000kPa ...
+# 500<Pressure Range＜1000 8 0~700kPa; -100~700kPa...
+# 260<Pressure Range≤500 16 0~500kPa; -100~300kPa...
+# 130<Pressure Range≤260 32 0~200kPa; -100~200kPa... <<< XGZP6847D100KPG
+# 65<Pressure Range≤130 64 0~100kPa; -100~100kPa; -100~0kPa... 
+# 32<Pressure Range≤65 128 0~40kPa; -40~40kPa; -40~0kPa... 
+# 16<Pressure Range≤32 256 0~20kPa; -20~20kPa; -20~0kPa; -30~0kPa...
+# 8<Pressure Range≤16 512 0~10kPa; -10~10kPa; -10~0kPa...
+# 4<Pressure Range≤8 1024 0~5kPa; -5~5kPa; -1~1PSI...
+# 2≤Pressure Range≤4 2048 0~2.5kPa; -2.5~2.5kPa...
+# 1≤Pressure Range<2 4096 0~1kPa; -1~1kPa...
+# Pressure Range<1 8192 -0.5~0.5kPa...
+
+k_dict = {
+    'XGZP6847D100KPG': 128. # 130<Pressure Range≤260 (absolute value)
+}
+
+class PumpPressureSensor:
+    # XGZP6847D vacuum pressure sensor
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+
+        self.i2c = bus.MCU_I2C_from_config(config, default_speed=100000, default_addr=XGZP6847D_FACTORY_ADDRESS)
+
+        self.active_read = False
+
+        self.pressure,  self.temperature, self.read_cycle = 0, 0, 0
+        self.timer = None
+
+        self.gcode.register_command('DO_PT_MEASURE', self.cmd_do_PT_measure,
+            desc="Start a pressure and temperature measurement cycle on the XGZP6847D sensor")
+        self.gcode.register_command('TELL_PT_MEASURE', self.cmd_tell_readings,
+            desc="Give a pressure and temperature measurement cycle on the XGZP6847D sensor")
+        
+        self.printer.register_event_handler("klippy:ready", self._handle_on_ready)
+
+               
+    def get_status(self, eventtime):
+        # Read pressure and temperature from the sensor
+        return {'Sampling Status': self.active_read, 'Pressure': self.pressure, 'Temperature': self.temperature}
+    def _handle_on_ready(self):
+        """Handle the 'klippy:ready' event to initialize the sensor."""
+        # Check the sensor if conncected or not. If not this line will issue a shutdown
+        self.i2c.i2c_read([REG_ADD_CMD], 1)
+        
+    def _do_read(self, eventtime):
+        # Confirm if the sampling is done
+        cmd_data = self.i2c.i2c_read([REG_ADD_CMD], 1)['response'][0]
+        done_s = (cmd_data & 0x08) >> 3
+        if done_s == READ_READY_STATE:
+            [p_msb, p_csb, p_lsb] = self.i2c.i2c_read([REG_ADD_P_DATA_MSB], 3)['response']
+            [t_msb, t_lsb] = self.i2c.i2c_read([REG_ADD_T_DATA_MSB], 2)['response']
+            # Convert raw values to signed integers
+            raw_pressure = (p_msb << 16) | (p_csb << 8) | p_lsb
+            if raw_pressure & 0x800000:
+                raw_pressure -= 0x1000000  # Convert to signed 24-bit int
+            self.pressure = raw_pressure/ k_dict['XGZP6847D100KPG']  # Convert to Pa using the K value
+            self.temperature = (t_msb << 8) | t_lsb
+            self.temperature = self.temperature / 256.  # Convert to Celsius
+            # Force to make this the last cycle
+            self.read_cycle = MAX_SAMPLING_CYCLE
+            logging.info(f"XGZP6847D sensor read completed: Pressure={self.pressure} Pa, Temperature={self.temperature} C")
+        else:
+            # If not done, increment the read cycle
+            self.read_cycle += 1
+        if self.read_cycle >= MAX_SAMPLING_CYCLE:
+            self.active_read = False
+            self.read_cycle = 0
+            if  done_s != READ_READY_STATE:
+                logging.warning("XGZP6847D sensor read timed out or failed.")
+            return self.reactor.NEVER
+        # If not done or not timed out, reschedule the read
+        return eventtime + SAMPLING_CYCLE_MS/1000.
+
+    def _read_sensor_data(self):
+        # Start sampling
+        self.i2c.i2c_write([REG_ADD_CMD, REG_DATA_CMD])
+        waketime = self.reactor.monotonic() + SAMPLING_CYCLE_MS/1000.
+        self.active_read = True
+        self.timer = self.reactor.register_timer(self._do_read, waketime)
+
+
+    def _stop_read(self):
+        """Stop the current sensor read operation."""
+        if self.active_read:
+            self.reactor.unregister_timer(self.timer)
+            self.active_read = False
+            self.read_cycle = 0
+            self.timer = None
+            logging.info("XGZP6847D sensor read stopped.")
+        else:
+            logging.warning("No active XGZP6847D sensor read to stop.")
+    # ---------------------------------------------------------------------
+    # GCode Command Handlers
+    # ---------------------------------------------------------------------
+    def cmd_do_PT_measure(self, gcmd):
+        """Start a pressure and temperature measurement cycle on the XGZP6847D sensor."""
+        if self.active_read:
+            logging.warning("cmd:XGZP6847D sensor read already in progress.")
+            gcmd.respond_info("cmd:XGZP6847D sensor read already in progress.")
+            return
+        self._read_sensor_data()
+        gcmd.respond_info("XGZP6847D sensor measurement started.")
+    
+    def cmd_tell_readings(self, gcmd):
+        # Read pressure and temperature from the sensor
+        if self.active_read:
+            logging.warning("XGZP6847D sensor read already in progress.")
+            gcmd.respond_info("XGZP6847D sensor read already in progress.")
+            return
+        gcmd.respond_info(f"XGZP6847D sensor readings: Pressure={self.pressure} Pa, Temperature={self.temperature} C")
+def load_config(config):
+    return PumpPressureSensor(config)

--- a/klippy/extras/dev_setup.py
+++ b/klippy/extras/dev_setup.py
@@ -15,7 +15,7 @@ class dev_setup:
         # Printer and pin setup
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
-        self.fakeHome = config.getboolean('fake_home', False, False)
+        self.fakeHome = config.getboolean('fake_home', False)
   
     # ---------------------------------------------------------------------
     # Event Handlers

--- a/klippy/extras/suction_controller.py
+++ b/klippy/extras/suction_controller.py
@@ -1,0 +1,107 @@
+#################################################################
+# Klippy Suction control Module @ Albatross
+# Description: This module provides klippy interface for suction
+#               pump control with i2c-based pressure sensor (XGZP6847D)
+# Date: 2025-06-26
+# Version: 0.1
+# Owner: Mo
+#################################################################
+from . import  output_pin
+from XGZP6847D_sensor import PumpPressureSensor
+
+class Pump:
+    def __init__(self, config, default_shutdown_pressure=0.):
+        self.printer = config.get_printer()
+        self.last_fan_value = self.last_req_value = 0.
+        # Read config
+        self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
+        self.kick_start_time = config.getfloat('kick_start_time', 0.1,
+                                               minval=0.)
+        self.off_below = config.getfloat('off_below', default=0.,
+                                         minval=0., maxval=1.)
+        cycle_time = config.getfloat('cycle_time', 0.010, above=0.)
+        hardware_pwm = config.getboolean('hardware_pwm', False)
+        shutdown_pressure = config.getfloat(
+            'shutdown_pressure', default_shutdown_pressure, minval=0., maxval=1.)
+        # Setup pwm object
+        ppins = self.printer.lookup_object('pins')
+        self.mcu_fan = ppins.setup_pin('pwm', config.get('pin'))
+        self.mcu_fan.setup_max_duration(0.)
+        self.mcu_fan.setup_cycle_time(cycle_time, hardware_pwm)
+        shutdown_power = max(0., min(self.max_power, shutdown_pressure))
+        self.mcu_fan.setup_start_value(0., shutdown_power)
+
+        self.enable_pin = None
+        enable_pin = config.get('enable_pin', None)
+        if enable_pin is not None:
+            self.enable_pin = ppins.setup_pin('digital_out', enable_pin)
+            self.enable_pin.setup_max_duration(0.)
+
+        # Create gcode request queue
+        self.gcrq = output_pin.GCodeRequestQueue(config, self.mcu_fan.get_mcu(),
+                                                 self._apply_pressure)
+
+        # Setup Pressure sensor
+        self.PressureSensor = PumpPressureSensor(config)
+
+        # Register callbacks
+        self.printer.register_event_handler("gcode:request_restart",
+                                            self._handle_request_restart)
+
+    def get_mcu(self):
+        return self.mcu_fan.get_mcu()
+    def _apply_pressure(self, print_time, value):
+        if value < self.off_below:
+            value = 0.
+        value = max(0., min(self.max_power, value * self.max_power))
+        if value == self.last_fan_value:
+            return "discard", 0.
+        if self.enable_pin:
+            if value > 0 and self.last_fan_value == 0:
+                self.enable_pin.set_digital(print_time, 1)
+            elif value == 0 and self.last_fan_value > 0:
+                self.enable_pin.set_digital(print_time, 0)
+        if (value and self.kick_start_time
+            and (not self.last_fan_value or value - self.last_fan_value > .5)):
+            # Run fan at full pressure for specified kick_start_time
+            self.last_req_value = value
+            self.last_fan_value = self.max_power
+            self.mcu_fan.set_pwm(print_time, self.max_power)
+            return "delay", self.kick_start_time
+        self.last_fan_value = self.last_req_value = value
+        self.mcu_fan.set_pwm(print_time, value)
+    def set_pressure(self, value, print_time=None):
+        self.gcrq.send_async_request(value, print_time)
+    def set_pressure_from_command(self, value):
+        self.gcrq.queue_gcode_request(value)
+    def _handle_request_restart(self, print_time):
+        self.set_pressure(0., print_time)
+
+    def get_status(self, eventtime):
+        PumpPressureSensor_status = self.PumpPressureSensor.get_status(eventtime)
+        return {
+            'Pump Power': self.last_req_value,
+            'Actual Pressure': PumpPressureSensor_status['pressure'],
+        }
+
+
+
+class PrinterPump:
+    def __init__(self, config):
+        self.pump = Pump(config)
+        # Register commands
+        gcode = config.get_printer().lookup_object('gcode')
+        gcode.register_command("M106", self.cmd_M106)
+        gcode.register_command("M107", self.cmd_M107)
+    def get_status(self, eventtime):
+        return self.pump.get_status(eventtime)
+    def cmd_M106(self, gcmd):
+        # Set fan pressure
+        value = gcmd.get_float('P', 255., minval=0.) / 255.
+        self.pump.set_pressure_from_command(value)
+    def cmd_M107(self, gcmd):
+        # Turn fan off
+        self.pump.set_pressure_from_command(0.)
+
+def load_config(config):
+    return PrinterPump(config)

--- a/klippy/extras/suction_controller.py
+++ b/klippy/extras/suction_controller.py
@@ -7,7 +7,7 @@
 # Owner: Mo
 #################################################################
 from . import  output_pin
-from XGZP6847D_sensor import PumpPressureSensor
+# from .XGZP6847D_sensor import XGZP6847D_sensor
 
 class Pump:
     def __init__(self, config, default_shutdown_pressure=0.):
@@ -42,7 +42,7 @@ class Pump:
                                                  self._apply_pressure)
 
         # Setup Pressure sensor
-        self.PressureSensor = PumpPressureSensor(config)
+        # self.PressureSensor = XGZP6847D_sensor(config)
 
         # Register callbacks
         self.printer.register_event_handler("gcode:request_restart",
@@ -50,6 +50,7 @@ class Pump:
 
     def get_mcu(self):
         return self.mcu_fan.get_mcu()
+    
     def _apply_pressure(self, print_time, value):
         if value < self.off_below:
             value = 0.
@@ -78,15 +79,17 @@ class Pump:
         self.set_pressure(0., print_time)
 
     def get_status(self, eventtime):
-        PumpPressureSensor_status = self.PumpPressureSensor.get_status(eventtime)
+        # PumpPressureSensor_status = self.PumpPressureSensor.get_status(eventtime)
         return {
             'Pump Power': self.last_req_value,
-            'Actual Pressure': PumpPressureSensor_status['pressure'],
+            # 'Actual Pressure': PumpPressureSensor_status['Pressure'],
+            # 'Temperature': PumpPressureSensor_status['Temperature'],
+            # 'Sampling Status': PumpPressureSensor_status['Sampling Status']
         }
 
 
 
-class PrinterPump:
+class suction_controller:
     def __init__(self, config):
         self.pump = Pump(config)
         # Register commands
@@ -104,4 +107,4 @@ class PrinterPump:
         self.pump.set_pressure_from_command(0.)
 
 def load_config(config):
-    return PrinterPump(config)
+    return suction_controller(config)


### PR DESCRIPTION
#  Add Klipper Integration Module for XGZP6847D Pressure Sensor

This PR introduces a new Klippy module for interfacing with the **XGZP6847D** vacuum pressure sensor via I2C. It enables pressure and temperature measurements using asynchronous read cycles and provides a GCode interface for printer-side access.

##  Module 1: pressure sensor module
- `XGZP6847D.py` — high-level Klippy integration for the XGZP6847D sensor
##  Module 2: suction controller
- `suction_controller.py` —  A custom controller for suction fans (currently mirrors standard fan behavior but is designed for future fusion with pressure feedback logic)
##  Configuration Example
```ini
[XGZP6847D_sensor]
i2c_bus: i2c0e
i2c_mcu: mu_mcu

[suction_controller]
pin: mu_mcu:gpio25
```
##  Features
- Automatically reads sensor status periodically for live monitoring  (get_status())
- Initializes and verifies sensor presence on Klipper startup  
- Starts combined pressure/temperature read via I2C with `DO_PT_MEASURE`  
- Reports last measured values via `TELL_PT_MEASURE`  


##  Supported GCodes
### XGZP6847D
- `DO_PT_MEASURE` — starts an async read cycle  
- `TELL_PT_MEASURE` — returns latest pressure and temperature values  
- `get_status(eventtime)` — internal Klipper query interface to check sampling state and last values  
### Suction Controller
- Custom fan-like device driver  
- Compatible with standard `M107 & M106` GCodes  
- Lays groundwork for future integration with pressure sensor feedback  

##  Notes
- The sensor is polled asynchronously using Klipper’s reactor system  
- Pressure is converted using the appropriate factory `K` value (128 for 100kPa full-scale range)  
- Timeouts and failure cases are logged with appropriate warnings  



